### PR TITLE
longer static caching

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,5 +1,5 @@
 {
   "projects": {
-    "default": "bulider-headless-shopify"
+    "default": "builder-shopify-starter"
   }
 }

--- a/firebase.json
+++ b/firebase.json
@@ -29,6 +29,15 @@
             "value": "max-age=300"
           }
         ]
+      },
+      {
+        "source": "**/*",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "public, max-age=600, s-maxage=2628000, stale-while-revalidate=2628000, stale-if-error=2628000"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
we can cache very a very long time for any shared (e.g. CDN) cache with firebase since firebase invalidates all caches on any code update / deploy